### PR TITLE
Add new statistics to getblockstats RPC

### DIFF
--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -43,6 +43,40 @@ std::string CTxIn::ToString() const
     return str;
 }
 
+
+bool CTxIn::SpendsNestedPayToWitnessPubKeyHashOutput(CScript spentScriptPubKey) const {
+    if ((!spentScriptPubKey.IsPayToScriptHash()) || scriptWitness.IsNull()) {
+        return false;
+    }
+
+    return scriptSig.IsNestedPayToWitnessPubKeyHashScriptSig();
+}
+
+bool CTxIn::SpendsNestedPayToWitnessScriptHashOutput(CScript spentScriptPubKey) const {
+    if (!(spentScriptPubKey.IsPayToScriptHash()) || scriptWitness.IsNull()) {
+        return false;
+    }
+
+    return scriptSig.IsNestedPayToWitnessScriptHashScriptSig();
+}
+
+bool CTxIn::SpendsNativePayToWitnessPubKeyHashOutput(CScript spentScriptPubKey) const {
+    if (scriptWitness.IsNull()) {
+        return false;
+    }
+
+    return spentScriptPubKey.IsNativePayToWitnessPubKeyHash();
+}
+
+bool CTxIn::SpendsNativePayToWitnessScriptHashOutput(CScript spentScriptPubKey) const {
+    if (scriptWitness.IsNull()) {
+        return false;
+    }
+
+    return spentScriptPubKey.IsPayToWitnessScriptHash();
+}
+
+
 CTxOut::CTxOut(const CAmount& nValueIn, CScript scriptPubKeyIn)
 {
     nValue = nValueIn;

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -123,6 +123,11 @@ public:
     }
 
     std::string ToString() const;
+
+    bool SpendsNestedPayToWitnessPubKeyHashOutput(CScript spentScriptPubKey) const;
+    bool SpendsNestedPayToWitnessScriptHashOutput(CScript spentScriptPubKey) const;
+    bool SpendsNativePayToWitnessPubKeyHashOutput(CScript spentScriptPubKey) const;
+    bool SpendsNativePayToWitnessScriptHashOutput(CScript spentScriptPubKey) const;
 };
 
 /** An output of a transaction.  It contains the public key that the next input

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1733,6 +1733,18 @@ static UniValue getblockstats(const JSONRPCRequest& request)
             "  \"txs\": xxxxx,             (numeric) The number of transactions (excluding coinbase)\n"
             "  \"utxo_increase\": xxxxx,   (numeric) The increase/decrease in the number of unspent outputs\n"
             "  \"utxo_size_inc\": xxxxx,   (numeric) The increase/decrease in size for the utxo index (not discounting op_return and similar)\n"
+            "  \"nested_p2wpkh_outputs_spent\": xxxxx,   (numeric) The total number of nested P2WPKH outputs spent\n"
+            "  \"nested_p2wsh_outputs_spent\": xxxxx,   (numeric) The total number of nested P2WSH outputs spent\n"
+            "  \"native_p2wpkh_outputs_spent\": xxxxx,   (numeric) The total number of native P2WPKH outputs spent\n"
+            "  \"native_p2wsh_outputs_spent\": xxxxx,   (numeric) The total number of native P2WSH outputs spent\n"
+            "  \"txs_spending_nested_p2wpkh_outputs\": xxxxx,   (numeric) The total number of transactions spending nested P2WPKH outputs\n"
+            "  \"txs_spending_nested_p2wsh_outputs\": xxxxx,   (numeric) The total number of transactions spending nested P2WSH outputs\n"
+            "  \"txs_spending_native_p2wpkh_outputs\": xxxxx,   (numeric) The total number of transactions spending native P2WPKH outputs\n"
+            "  \"txs_spending_native_p2wsh_outputs\": xxxxx,   (numeric) The total number of transactions spending native P2WSH outputs\n"
+            "  \"new_p2wpkh_outputs\": xxxxx,   (numeric) The total number of new P2WPKH outputs\n"
+            "  \"new_p2wsh_outputs\": xxxxx,   (numeric) The total number of new P2WSH outputs\n"
+            "  \"txs_creating_p2wpkh_outputs\": xxxxx,   (numeric) The total number of transactions creating new P2WPKH outputs\n"
+            "  \"txs_creating_p2wsh_outputs\": xxxxx,   (numeric) The total number of transactions new P2WSH outputs\n"
             "}\n"
             "\nExamples:\n"
             + HelpExampleCli("getblockstats", "1000 '[\"minfeerate\",\"avgfeerate\"]'")
@@ -1810,16 +1822,50 @@ static UniValue getblockstats(const JSONRPCRequest& request)
     std::vector<CAmount> fee_array;
     std::vector<std::pair<CAmount, int64_t>> feerate_array;
     std::vector<int64_t> txsize_array;
+    int64_t native_p2wpkh_outputs_spent = 0;
+    int64_t native_p2wsh_outputs_spent = 0;
+    int64_t nested_p2wpkh_outputs_spent = 0;
+    int64_t nested_p2wsh_outputs_spent = 0;
+    int64_t txs_spending_nested_p2wpkh_outputs = 0;
+    int64_t txs_spending_nested_p2wsh_outputs = 0;
+    int64_t txs_spending_native_p2wpkh_outputs = 0;
+    int64_t txs_spending_native_p2wsh_outputs = 0;
+    int64_t new_p2wpkh_outputs = 0;
+    int64_t new_p2wsh_outputs = 0;
+    int64_t txs_creating_p2wpkh_outputs = 0;
+    int64_t txs_creating_p2wsh_outputs = 0;
 
     for (const auto& tx : block.vtx) {
         outputs += tx->vout.size();
 
+        bool creates_p2wpkh_output = false;
+        bool creates_p2wsh_output = false;
+
         CAmount tx_total_out = 0;
         if (loop_outputs) {
             for (const CTxOut& out : tx->vout) {
+                CScript scriptPubKey = out.scriptPubKey;
+
+                // Check what kinds of output is being created.
+                if (scriptPubKey.IsPayToWitnessScriptHash()) {
+                    ++new_p2wsh_outputs;
+                    creates_p2wsh_output = true;
+                } else if (scriptPubKey.IsNativePayToWitnessPubKeyHash()) {
+                    ++new_p2wpkh_outputs;
+                    creates_p2wpkh_output = true;
+                }
+
                 tx_total_out += out.nValue;
                 utxo_size_inc += GetSerializeSize(out, SER_NETWORK, PROTOCOL_VERSION) + PER_UTXO_OVERHEAD;
             }
+        }
+
+        if (creates_p2wpkh_output) {
+            ++txs_creating_p2wpkh_outputs;
+        }
+
+        if (creates_p2wsh_output) {
+            ++txs_creating_p2wsh_outputs;
         }
 
         if (tx->IsCoinBase()) {
@@ -1854,11 +1900,15 @@ static UniValue getblockstats(const JSONRPCRequest& request)
         }
 
         if (loop_inputs) {
-
             if (!g_txindex) {
                 throw JSONRPCError(RPC_INVALID_PARAMETER, "One or more of the selected stats requires -txindex enabled");
             }
+
             CAmount tx_total_in = 0;
+            bool spends_nested_p2wpkh_output = false;
+            bool spends_nested_p2wsh_output = false;
+            bool spends_native_p2wpkh_output = false;
+            bool spends_native_p2wsh_output = false;
             for (const CTxIn& in : tx->vin) {
                 CTransactionRef tx_in;
                 uint256 hashBlock;
@@ -1868,8 +1918,42 @@ static UniValue getblockstats(const JSONRPCRequest& request)
 
                 CTxOut prevoutput = tx_in->vout[in.prevout.n];
 
+                // Check what kind of output is being spent..
+                CScript scriptPubKey = prevoutput.scriptPubKey;
+                if (in.SpendsNestedPayToWitnessPubKeyHashOutput(scriptPubKey)) {
+                    spends_nested_p2wpkh_output = true;
+                    ++nested_p2wpkh_outputs_spent;
+                } else if (in.SpendsNestedPayToWitnessScriptHashOutput(scriptPubKey)) {
+                    spends_nested_p2wsh_output = true;
+                    ++nested_p2wsh_outputs_spent;
+                } else if (in.SpendsNativePayToWitnessPubKeyHashOutput(scriptPubKey)) {
+                    spends_native_p2wpkh_output = true;
+                    ++native_p2wpkh_outputs_spent;
+                } else if (in.SpendsNativePayToWitnessScriptHashOutput(scriptPubKey)) {
+                    spends_native_p2wsh_output = true;
+                    ++native_p2wsh_outputs_spent;
+                }
+
                 tx_total_in += prevoutput.nValue;
                 utxo_size_inc -= GetSerializeSize(prevoutput, SER_NETWORK, PROTOCOL_VERSION) + PER_UTXO_OVERHEAD;
+            }
+
+            // Sanity check: any transaction with a witness must have spent one of these SW output types.
+            if (tx->HasWitness()) {
+                assert(spends_native_p2wsh_output || spends_native_p2wpkh_output || spends_nested_p2wsh_output || spends_nested_p2wpkh_output);
+            }
+
+            if (spends_nested_p2wpkh_output) {
+                ++txs_spending_nested_p2wpkh_outputs;
+            }
+            if (spends_nested_p2wsh_output) {
+                ++txs_spending_nested_p2wsh_outputs;
+            }
+            if (spends_native_p2wpkh_output) {
+                ++txs_spending_native_p2wpkh_outputs;
+            }
+            if (spends_native_p2wsh_output) {
+                ++txs_spending_native_p2wsh_outputs;
             }
 
             CAmount txfee = tx_total_in - tx_total_out;
@@ -1929,6 +2013,18 @@ static UniValue getblockstats(const JSONRPCRequest& request)
     ret_all.pushKV("txs", (int64_t)block.vtx.size());
     ret_all.pushKV("utxo_increase", outputs - inputs);
     ret_all.pushKV("utxo_size_inc", utxo_size_inc);
+    ret_all.pushKV("nested_p2wpkh_outputs_spent", nested_p2wpkh_outputs_spent);
+    ret_all.pushKV("nested_p2wsh_outputs_spent", nested_p2wsh_outputs_spent);
+    ret_all.pushKV("native_p2wpkh_outputs_spent", native_p2wpkh_outputs_spent);
+    ret_all.pushKV("native_p2wsh_outputs_spent", native_p2wsh_outputs_spent);
+    ret_all.pushKV("txs_spending_nested_p2wpkh_outputs", txs_spending_nested_p2wpkh_outputs);
+    ret_all.pushKV("txs_spending_nested_p2wsh_outputs", txs_spending_nested_p2wsh_outputs);
+    ret_all.pushKV("txs_spending_native_p2wpkh_outputs", txs_spending_native_p2wpkh_outputs);
+    ret_all.pushKV("txs_spending_native_p2wsh_outputs", txs_spending_native_p2wsh_outputs);
+    ret_all.pushKV("new_p2wpkh_outputs", new_p2wpkh_outputs);
+    ret_all.pushKV("new_p2wsh_outputs", new_p2wsh_outputs);
+    ret_all.pushKV("txs_creating_p2wpkh_outputs", txs_creating_p2wpkh_outputs);
+    ret_all.pushKV("txs_creating_p2wsh_outputs", txs_creating_p2wsh_outputs);
 
     if (do_all) {
         return ret_all;

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1753,6 +1753,8 @@ static UniValue getblockstats(const JSONRPCRequest& request)
             "  \"txs_batching\": xxxxx,   (numeric) The total number batching transactions (defined as at least 3 outputs)\n"
             "  \"outcount_bins\": xxxxx,   (numeric_array) The numbers of transactions that have certain numbers of outputs\n"
             "  \"dust_bins\": xxxxx,   (numeric_array) The total number of outputs that are dust at several fee-rates\n"
+            "  \"mto_consolidations\": xxxxx,   (numeric) The total number of transactions with at least 3 inputs and exactly 1 output\n"
+            "  \"mto_output_count\": xxxxx,   (numeric) The total number of outputs spent in all mto_consolidation transactions\n"
             "}\n"
             "\nExamples:\n"
             + HelpExampleCli("getblockstats", "1000 '[\"minfeerate\",\"avgfeerate\"]'")
@@ -1847,6 +1849,11 @@ static UniValue getblockstats(const JSONRPCRequest& request)
     int64_t outputs_consolidated = 0;
     int64_t txs_batching = 0;
 
+    std::vector<CTxDestination> high_consolidation_addrs;
+    std::vector<int64_t> cons_in_count;
+    int64_t many_to_one_consolidating_txs = 0;
+    int64_t many_to_one_consolidated_outputs = 0;
+
     // Batch ranges =  [(1), (2), (3-4), (5-9), (10-49), (50-99), (100+)]
     constexpr int NUM_OUTCOUNT_BINS = 7;
     int64_t output_count_bins[NUM_OUTCOUNT_BINS] = {0};
@@ -1924,6 +1931,12 @@ static UniValue getblockstats(const JSONRPCRequest& request)
         if (tx->vin.size() >= CONSOLIDATION_THRESHOLD) {
             ++txs_consolidating;
             outputs_consolidated += tx->vin.size();
+        }
+
+        // Look for transactions with high number of inputs and low outputs
+        if ((tx->vin.size() >= CONSOLIDATION_THRESHOLD) && tx->vout.size() == 1) {
+          ++many_to_one_consolidating_txs;
+          many_to_one_consolidated_outputs += tx->vin.size();
         }
 
         int64_t tx_size = 0;
@@ -2108,6 +2121,9 @@ static UniValue getblockstats(const JSONRPCRequest& request)
     }
     ret_all.pushKV("dust_bins", dust_res);
 
+    ret_all.pushKV("mto_consolidations", many_to_one_consolidating_txs);
+    ret_all.pushKV("mto_output_count", many_to_one_consolidated_outputs);
+
     if (do_all) {
         return ret_all;
     }
@@ -2120,6 +2136,7 @@ static UniValue getblockstats(const JSONRPCRequest& request)
         }
         ret.pushKV(stat, value);
     }
+
     return ret;
 }
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1745,6 +1745,7 @@ static UniValue getblockstats(const JSONRPCRequest& request)
             "  \"new_p2wsh_outputs\": xxxxx,   (numeric) The total number of new P2WSH outputs\n"
             "  \"txs_creating_p2wpkh_outputs\": xxxxx,   (numeric) The total number of transactions creating new P2WPKH outputs\n"
             "  \"txs_creating_p2wsh_outputs\": xxxxx,   (numeric) The total number of transactions new P2WSH outputs\n"
+            "  \"dust_bins\": xxxxx,   (numeric_array) The total number of outputs that are dust at several fee-rates\n"
             "}\n"
             "\nExamples:\n"
             + HelpExampleCli("getblockstats", "1000 '[\"minfeerate\",\"avgfeerate\"]'")
@@ -1835,6 +1836,10 @@ static UniValue getblockstats(const JSONRPCRequest& request)
     int64_t txs_creating_p2wpkh_outputs = 0;
     int64_t txs_creating_p2wsh_outputs = 0;
 
+    const int NUM_DUST_BINS = 22;
+    int64_t dustbin_array[NUM_DUST_BINS] = {0};
+    const CFeeRate dust_fee_rates[NUM_DUST_BINS] = {CFeeRate(1*1000), CFeeRate(3*1000), CFeeRate(5*1000), CFeeRate(8*1000), CFeeRate(10*1000), CFeeRate(15*1000), CFeeRate(20*1000), CFeeRate(25*1000), CFeeRate(30*1000), CFeeRate(40*1000), CFeeRate(50*1000), CFeeRate(60*1000), CFeeRate(70*1000), CFeeRate(80*1000), CFeeRate(90*1000),  CFeeRate(100*1000), CFeeRate(150*1000),CFeeRate(200*1000),  CFeeRate(250*1000), CFeeRate(350*1000), CFeeRate(500*1000), CFeeRate(1000*1000)};
+
     for (const auto& tx : block.vtx) {
         outputs += tx->vout.size();
 
@@ -1857,6 +1862,14 @@ static UniValue getblockstats(const JSONRPCRequest& request)
 
                 tx_total_out += out.nValue;
                 utxo_size_inc += GetSerializeSize(out, SER_NETWORK, PROTOCOL_VERSION) + PER_UTXO_OVERHEAD;
+
+                // Check if output is dust at any of the set fee rates.
+                for (int64_t i = 0; i < NUM_DUST_BINS; i++) {
+                    if (IsDust(out, dust_fee_rates[i])) {
+                        ++dustbin_array[i];
+                        break;
+                    }
+                }
             }
         }
 
@@ -1983,6 +1996,11 @@ static UniValue getblockstats(const JSONRPCRequest& request)
         feerates_res.push_back(feerate_percentiles[i]);
     }
 
+    // If an output is dust at fee rate x s.t. x < y, then it is dust at y.
+    for (int64_t i = 0; i < NUM_DUST_BINS - 1; i++) {
+      dustbin_array[i+1] += dustbin_array[i];
+    }
+
     UniValue ret_all(UniValue::VOBJ);
     ret_all.pushKV("avgfee", (block.vtx.size() > 1) ? totalfee / (block.vtx.size() - 1) : 0);
     ret_all.pushKV("avgfeerate", total_weight ? (totalfee * WITNESS_SCALE_FACTOR) / total_weight : 0); // Unit: sat/vbyte
@@ -2025,6 +2043,11 @@ static UniValue getblockstats(const JSONRPCRequest& request)
     ret_all.pushKV("new_p2wsh_outputs", new_p2wsh_outputs);
     ret_all.pushKV("txs_creating_p2wpkh_outputs", txs_creating_p2wpkh_outputs);
     ret_all.pushKV("txs_creating_p2wsh_outputs", txs_creating_p2wsh_outputs);
+    UniValue dust_res(UniValue::VARR);
+    for (int64_t i = 0; i < NUM_DUST_BINS; i++) {
+      dust_res.push_back(dustbin_array[i]);
+    }
+    ret_all.pushKV("dust_bins", dust_res);
 
     if (do_all) {
         return ret_all;

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1679,6 +1679,8 @@ static inline bool SetHasKeys(const std::set<T>& set, const Tk& key, const Args&
 
 // outpoint (needed for the utxo index) + nHeight + fCoinBase
 static constexpr size_t PER_UTXO_OVERHEAD = sizeof(COutPoint) + sizeof(uint32_t) + sizeof(bool);
+static constexpr int CONSOLIDATION_THRESHOLD = 3;
+static constexpr int BATCHING_THRESHOLD = 3; // If the transaction has at least 3 outputs, it's considered batching.
 
 static UniValue getblockstats(const JSONRPCRequest& request)
 {
@@ -1745,6 +1747,11 @@ static UniValue getblockstats(const JSONRPCRequest& request)
             "  \"new_p2wsh_outputs\": xxxxx,   (numeric) The total number of new P2WSH outputs\n"
             "  \"txs_creating_p2wpkh_outputs\": xxxxx,   (numeric) The total number of transactions creating new P2WPKH outputs\n"
             "  \"txs_creating_p2wsh_outputs\": xxxxx,   (numeric) The total number of transactions new P2WSH outputs\n"
+            "  \"txs_signalling_opt_in_rbf\": xxxxx,   (numeric) The total number of transactions that signal RBF\n"
+            "  \"txs_consolidating\": xxxxx,   (numeric) The total number of consolidating transactions (defined as at least 3 inputs and 1 output)\n"
+            "  \"outputs_consolidated\": xxxxx,   (numeric) The total number of outputs created by a consolidating transaction\n"
+            "  \"txs_batching\": xxxxx,   (numeric) The total number batching transactions (defined as at least 3 outputs)\n"
+            "  \"outcount_bins\": xxxxx,   (numeric_array) The numbers of transactions that have certain numbers of outputs\n"
             "  \"dust_bins\": xxxxx,   (numeric_array) The total number of outputs that are dust at several fee-rates\n"
             "}\n"
             "\nExamples:\n"
@@ -1835,17 +1842,43 @@ static UniValue getblockstats(const JSONRPCRequest& request)
     int64_t new_p2wsh_outputs = 0;
     int64_t txs_creating_p2wpkh_outputs = 0;
     int64_t txs_creating_p2wsh_outputs = 0;
+    int64_t txs_signalling_opt_in_rbf = 0;
+    int64_t txs_consolidating = 0;
+    int64_t outputs_consolidated = 0;
+    int64_t txs_batching = 0;
 
-    const int NUM_DUST_BINS = 22;
+    // Batch ranges =  [(1), (2), (3-4), (5-9), (10-49), (50-99), (100+)]
+    constexpr int NUM_OUTCOUNT_BINS = 7;
+    int64_t output_count_bins[NUM_OUTCOUNT_BINS] = {0};
+    const int64_t out_counts[NUM_OUTCOUNT_BINS+1] = {1, 2, 3, 5, 10, 50, 100};
+
+    constexpr int NUM_DUST_BINS = 22;
     int64_t dustbin_array[NUM_DUST_BINS] = {0};
     const CFeeRate dust_fee_rates[NUM_DUST_BINS] = {CFeeRate(1*1000), CFeeRate(3*1000), CFeeRate(5*1000), CFeeRate(8*1000), CFeeRate(10*1000), CFeeRate(15*1000), CFeeRate(20*1000), CFeeRate(25*1000), CFeeRate(30*1000), CFeeRate(40*1000), CFeeRate(50*1000), CFeeRate(60*1000), CFeeRate(70*1000), CFeeRate(80*1000), CFeeRate(90*1000),  CFeeRate(100*1000), CFeeRate(150*1000),CFeeRate(200*1000),  CFeeRate(250*1000), CFeeRate(350*1000), CFeeRate(500*1000), CFeeRate(1000*1000)};
 
     for (const auto& tx : block.vtx) {
-        outputs += tx->vout.size();
+        int64_t tx_outputs = tx->vout.size();
+        outputs += tx_outputs;
+
+        // Place number of outputs for this transaction into the corresponding bin.
+        for (int64_t i = 0; i < NUM_OUTCOUNT_BINS; i++) {
+          if (i == NUM_OUTCOUNT_BINS - 1) {
+              ++output_count_bins[i];
+              break;
+          }
+
+          if (tx_outputs >= out_counts[i] &&  tx_outputs < out_counts[i+1]) {
+              ++output_count_bins[i];
+              break;
+          }
+        }
+
+        if (tx_outputs >= BATCHING_THRESHOLD) {
+            ++txs_batching;
+        }
 
         bool creates_p2wpkh_output = false;
         bool creates_p2wsh_output = false;
-
         CAmount tx_total_out = 0;
         if (loop_outputs) {
             for (const CTxOut& out : tx->vout) {
@@ -1888,6 +1921,11 @@ static UniValue getblockstats(const JSONRPCRequest& request)
         inputs += tx->vin.size(); // Don't count coinbase's fake input
         total_out += tx_total_out; // Don't count coinbase reward
 
+        if (tx->vin.size() >= CONSOLIDATION_THRESHOLD) {
+            ++txs_consolidating;
+            outputs_consolidated += tx->vin.size();
+        }
+
         int64_t tx_size = 0;
         if (do_calculate_size) {
 
@@ -1922,11 +1960,17 @@ static UniValue getblockstats(const JSONRPCRequest& request)
             bool spends_nested_p2wsh_output = false;
             bool spends_native_p2wpkh_output = false;
             bool spends_native_p2wsh_output = false;
+            bool signals_opt_in_rbf = false;
             for (const CTxIn& in : tx->vin) {
                 CTransactionRef tx_in;
                 uint256 hashBlock;
                 if (!GetTransaction(in.prevout.hash, tx_in, Params().GetConsensus(), hashBlock, false)) {
                     throw JSONRPCError(RPC_INTERNAL_ERROR, std::string("Unexpected internal error (tx index seems corrupt)"));
+                }
+
+                // Copied from inner loop of CTransaction::SignalsOptInRBF
+                if (in.nSequence < std::numeric_limits<unsigned int>::max()-1) {
+                    signals_opt_in_rbf = true;
                 }
 
                 CTxOut prevoutput = tx_in->vout[in.prevout.n];
@@ -1949,6 +1993,10 @@ static UniValue getblockstats(const JSONRPCRequest& request)
 
                 tx_total_in += prevoutput.nValue;
                 utxo_size_inc -= GetSerializeSize(prevoutput, SER_NETWORK, PROTOCOL_VERSION) + PER_UTXO_OVERHEAD;
+            }
+
+            if (signals_opt_in_rbf) {
+              ++txs_signalling_opt_in_rbf;
             }
 
             // Sanity check: any transaction with a witness must have spent one of these SW output types.
@@ -2043,6 +2091,17 @@ static UniValue getblockstats(const JSONRPCRequest& request)
     ret_all.pushKV("new_p2wsh_outputs", new_p2wsh_outputs);
     ret_all.pushKV("txs_creating_p2wpkh_outputs", txs_creating_p2wpkh_outputs);
     ret_all.pushKV("txs_creating_p2wsh_outputs", txs_creating_p2wsh_outputs);
+    ret_all.pushKV("txs_signalling_opt_in_rbf", txs_signalling_opt_in_rbf);
+    ret_all.pushKV("txs_consolidating", txs_consolidating);
+    ret_all.pushKV("outputs_consolidated", outputs_consolidated);
+    ret_all.pushKV("txs_batching", txs_batching);
+
+    UniValue outcount_res(UniValue::VARR);
+    for (int64_t i = 0; i < NUM_OUTCOUNT_BINS; i++) {
+      outcount_res.push_back(output_count_bins[i]);
+    }
+    ret_all.pushKV("output_count_bins", outcount_res);
+
     UniValue dust_res(UniValue::VARR);
     for (int64_t i = 0; i < NUM_DUST_BINS; i++) {
       dust_res.push_back(dustbin_array[i]);

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1755,6 +1755,13 @@ static UniValue getblockstats(const JSONRPCRequest& request)
             "  \"dust_bins\": xxxxx,   (numeric_array) The total number of outputs that are dust at several fee-rates\n"
             "  \"mto_consolidations\": xxxxx,   (numeric) The total number of transactions with at least 3 inputs and exactly 1 output\n"
             "  \"mto_output_count\": xxxxx,   (numeric) The total number of outputs spent in all mto_consolidation transactions\n"
+            "  \"mto_total_value\": xxxxx,   (numeric) The sum of values of all outputs from mto_consolidation transactions\n"
+            "  \"value_of_nested_p2wpkh_outputs_spent\": xxxxx,   (numeric) The total value of spent nested P2WPKH outputs\n"
+            "  \"value_of_nested_p2wsh_outputs_spent\": xxxxx,   (numeric) The total value of spent nested P2WSH outputs\n"
+            "  \"value_of_native_p2wpkh_outputs_spent\": xxxxx,   (numeric) The total value of spent native P2WPKH outputs\n"
+            "  \"value_of_native_p2wsh_outputs_spent\": xxxxx,   (numeric) The total value of spent native P2WSH outputs\n"
+            "  \"value_of_native_p2wpkh_outputs_created\": xxxxx,   (numeric) The total value of new native P2WPKH outputs\n"
+            "  \"value_of_native_p2wsh_outputs_created\": xxxxx,   (numeric) The total value of new native P2WSH outputs\n"
             "}\n"
             "\nExamples:\n"
             + HelpExampleCli("getblockstats", "1000 '[\"minfeerate\",\"avgfeerate\"]'")
@@ -1800,7 +1807,6 @@ static UniValue getblockstats(const JSONRPCRequest& request)
     }
 
     const CBlock block = GetBlockChecked(pindex);
-
     const bool do_all = stats.size() == 0; // Calculate everything if nothing selected (default)
     const bool do_mediantxsize = do_all || stats.count("mediantxsize") != 0;
     const bool do_medianfee = do_all || stats.count("medianfee") != 0;
@@ -1836,6 +1842,12 @@ static UniValue getblockstats(const JSONRPCRequest& request)
     int64_t native_p2wsh_outputs_spent = 0;
     int64_t nested_p2wpkh_outputs_spent = 0;
     int64_t nested_p2wsh_outputs_spent = 0;
+    int64_t value_of_native_p2wpkh_outputs_created = 0;
+    int64_t value_of_native_p2wsh_outputs_created = 0;
+    int64_t value_of_native_p2wpkh_outputs_spent = 0;
+    int64_t value_of_native_p2wsh_outputs_spent = 0;
+    int64_t value_of_nested_p2wpkh_outputs_spent = 0;
+    int64_t value_of_nested_p2wsh_outputs_spent = 0;
     int64_t txs_spending_nested_p2wpkh_outputs = 0;
     int64_t txs_spending_nested_p2wsh_outputs = 0;
     int64_t txs_spending_native_p2wpkh_outputs = 0;
@@ -1853,6 +1865,7 @@ static UniValue getblockstats(const JSONRPCRequest& request)
     std::vector<int64_t> cons_in_count;
     int64_t many_to_one_consolidating_txs = 0;
     int64_t many_to_one_consolidated_outputs = 0;
+    CAmount many_to_one_total_value = 0;
 
     // Batch ranges =  [(1), (2), (3-4), (5-9), (10-49), (50-99), (100+)]
     constexpr int NUM_OUTCOUNT_BINS = 7;
@@ -1895,9 +1908,11 @@ static UniValue getblockstats(const JSONRPCRequest& request)
                 if (scriptPubKey.IsPayToWitnessScriptHash()) {
                     ++new_p2wsh_outputs;
                     creates_p2wsh_output = true;
+                    value_of_native_p2wsh_outputs_created += out.nValue;
                 } else if (scriptPubKey.IsNativePayToWitnessPubKeyHash()) {
                     ++new_p2wpkh_outputs;
                     creates_p2wpkh_output = true;
+                    value_of_native_p2wpkh_outputs_created += out.nValue;
                 }
 
                 tx_total_out += out.nValue;
@@ -1933,10 +1948,12 @@ static UniValue getblockstats(const JSONRPCRequest& request)
             outputs_consolidated += tx->vin.size();
         }
 
+        bool tx_is_many_to_one = false;
         // Look for transactions with high number of inputs and low outputs
         if ((tx->vin.size() >= CONSOLIDATION_THRESHOLD) && tx->vout.size() == 1) {
           ++many_to_one_consolidating_txs;
           many_to_one_consolidated_outputs += tx->vin.size();
+          tx_is_many_to_one = true;
         }
 
         int64_t tx_size = 0;
@@ -1993,15 +2010,19 @@ static UniValue getblockstats(const JSONRPCRequest& request)
                 if (in.SpendsNestedPayToWitnessPubKeyHashOutput(scriptPubKey)) {
                     spends_nested_p2wpkh_output = true;
                     ++nested_p2wpkh_outputs_spent;
+                    value_of_nested_p2wpkh_outputs_spent += prevoutput.nValue;
                 } else if (in.SpendsNestedPayToWitnessScriptHashOutput(scriptPubKey)) {
                     spends_nested_p2wsh_output = true;
                     ++nested_p2wsh_outputs_spent;
+                    value_of_nested_p2wsh_outputs_spent += prevoutput.nValue;
                 } else if (in.SpendsNativePayToWitnessPubKeyHashOutput(scriptPubKey)) {
                     spends_native_p2wpkh_output = true;
                     ++native_p2wpkh_outputs_spent;
+                    value_of_native_p2wpkh_outputs_spent += prevoutput.nValue;
                 } else if (in.SpendsNativePayToWitnessScriptHashOutput(scriptPubKey)) {
                     spends_native_p2wsh_output = true;
                     ++native_p2wsh_outputs_spent;
+                    value_of_native_p2wsh_outputs_spent += prevoutput.nValue;
                 }
 
                 tx_total_in += prevoutput.nValue;
@@ -2046,6 +2067,10 @@ static UniValue getblockstats(const JSONRPCRequest& request)
             }
             maxfeerate = std::max(maxfeerate, feerate);
             minfeerate = std::min(minfeerate, feerate);
+
+            if (tx_is_many_to_one) {
+                many_to_one_total_value += tx_total_out;
+            }
         }
     }
 
@@ -2123,6 +2148,14 @@ static UniValue getblockstats(const JSONRPCRequest& request)
 
     ret_all.pushKV("mto_consolidations", many_to_one_consolidating_txs);
     ret_all.pushKV("mto_output_count", many_to_one_consolidated_outputs);
+    ret_all.pushKV("mto_total_value", many_to_one_total_value);
+
+    ret_all.pushKV("value_of_nested_p2wpkh_outputs_spent", value_of_nested_p2wpkh_outputs_spent);
+    ret_all.pushKV("value_of_nested_p2wsh_outputs_spent", value_of_nested_p2wsh_outputs_spent);
+    ret_all.pushKV("value_of_native_p2wpkh_outputs_spent", value_of_native_p2wpkh_outputs_spent);
+    ret_all.pushKV("value_of_native_p2wsh_outputs_spent", value_of_native_p2wsh_outputs_spent);
+    ret_all.pushKV("value_of_native_p2wpkh_outputs_created", value_of_native_p2wpkh_outputs_created);
+    ret_all.pushKV("value_of_native_p2wsh_outputs_created", value_of_native_p2wsh_outputs_created);
 
     if (do_all) {
         return ret_all;

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -211,6 +211,31 @@ bool CScript::IsPayToWitnessScriptHash() const
             (*this)[1] == 0x20);
 }
 
+bool CScript::IsNativePayToWitnessPubKeyHash() const
+{
+  // Extra-fast test for native pay-to-witness-pubkey-hash CScripts:
+    return (this->size() == 22 &&
+            (*this)[0] == OP_0 &&
+            (*this)[1] == 0x14);
+}
+
+bool CScript::IsNestedPayToWitnessPubKeyHashScriptSig() const
+{
+    return (this->size() == 23 &&
+            (*this)[0] == 0x16 &&
+            (*this)[1] == 0x00 &&
+            (*this)[2] == 0x14);
+}
+
+bool CScript::IsNestedPayToWitnessScriptHashScriptSig() const
+{
+    return (this->size() == 35 &&
+            (*this)[0] == 0x22 &&
+            (*this)[1] == 0x00 &&
+            (*this)[2] == 0x20);
+}
+
+
 // A witness program is any valid CScript that consists of a 1-byte push opcode
 // followed by a data push between 2 and 40 bytes.
 bool CScript::IsWitnessProgram(int& version, std::vector<unsigned char>& program) const

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -532,6 +532,10 @@ public:
 
     bool IsPayToScriptHash() const;
     bool IsPayToWitnessScriptHash() const;
+    bool IsNativePayToWitnessPubKeyHash() const;
+    bool IsNestedPayToWitnessPubKeyHashScriptSig() const;
+    bool IsNestedPayToWitnessScriptHashScriptSig() const;
+
     bool IsWitnessProgram(int& version, std::vector<unsigned char>& program) const;
 
     /** Called by IsStandardTx and P2SH/BIP62 VerifyScript (which makes it consensus-critical). */

--- a/src/test/script_standard_tests.cpp
+++ b/src/test/script_standard_tests.cpp
@@ -99,6 +99,8 @@ BOOST_AUTO_TEST_CASE(script_standard_Solver_success)
     BOOST_CHECK_EQUAL(whichType, TX_WITNESS_V0_KEYHASH);
     BOOST_CHECK_EQUAL(solutions.size(), 1U);
     BOOST_CHECK(solutions[0] == ToByteVector(pubkeys[0].GetID()));
+    BOOST_CHECK(s.IsNativePayToWitnessPubKeyHash());
+    BOOST_CHECK(!s.IsPayToWitnessScriptHash());
 
     // TX_WITNESS_V0_SCRIPTHASH
     uint256 scriptHash;
@@ -111,6 +113,8 @@ BOOST_AUTO_TEST_CASE(script_standard_Solver_success)
     BOOST_CHECK_EQUAL(whichType, TX_WITNESS_V0_SCRIPTHASH);
     BOOST_CHECK_EQUAL(solutions.size(), 1U);
     BOOST_CHECK(solutions[0] == ToByteVector(scriptHash));
+    BOOST_CHECK(s.IsPayToWitnessScriptHash());
+    BOOST_CHECK(!s.IsNativePayToWitnessPubKeyHash());
 
     // TX_NONSTANDARD
     s.clear();


### PR DESCRIPTION
Extends getblockstats RPC introduced in #10757.

`getblockstats` now tracks spends of specific SegWit output types: P2SH-nested P2WPKH, P2SH-nested P2WSH, native P2WPKH, and native P2WSH.  New `CTxIn` and `CScript` methods added to check that the scriptSig and  scriptPubKey of a input and the ouput it spends match the format of the above output types as specified in BIP 141. (Note: there is probably a bug in this part of the PR!) Also tracks creation of new native SegWit outputs using the same new methods.

This PR also introduces a count of transactions that signal RBF. It also adds batching, consolidation, and dust-creation metrics. 

A batching transaction is defined as having at least 3 outputs. Separately, this RPC now counts transactions that have fit into different ranges of their number of outputs.  ` //  Batch ranges =  [(1), (2), (3-4), (5-9), (10-49), (50-99), (100+)] ` These ranges are predetermined but arbitrary .

A consolidating transaction is defined as having at least 3 inputs. 

Dust creation is calculated by using the `IsDust` function on each output at different fee-rates. The outputs are then put into bins of different ranges (e.g. dust at 100 sat/vbyte or higher. These ranges are also predetermined but arbitrary .

