### PR TITLE
Make python calls generic over bytes/int

### DIFF
--- a/test/functional/test_framework/key.py
+++ b/test/functional/test_framework/key.py
@@ -249,6 +249,7 @@ class ECPubKey():
                 self.valid = False
         else:
             self.valid = False
+        return self
 
     @property
     def is_compressed(self):
@@ -418,10 +419,12 @@ class ECKey():
         if self.valid:
             self.secret = secret
             self.compressed = compressed
+        return self
 
     def generate(self, compressed=True):
         """Generate a random private key (compressed or uncompressed)."""
         self.set(random.randrange(1, SECP256K1_ORDER).to_bytes(32, 'big'), compressed)
+        return self
 
     def get_bytes(self):
         """Retrieve the 32-byte representation of this key."""


### PR DESCRIPTION
This should make the code more ergonomic as discussed here:
https://github.com/bitcoinops/taproot-workshop/issues/28

I also cherry-picked a commit I did for upstream to return self from functions so we can do:
`key = ECKey().set(data)` or `key = ECKey().generate()`