### PR TITLE
Changes to the python lib

### DIFF
--- a/test/functional/test_framework/key.py
+++ b/test/functional/test_framework/key.py
@@ -268,6 +268,12 @@ class ECPubKey():
     def is_valid(self):
         return self.valid
 
+    def get_y(self):
+        return SECP256K1.affine(self)[1]
+
+    def get_x(self):
+        return SECP256K1.affine(self)[0]
+
     def get_bytes(self):
         assert(self.valid)
         p = SECP256K1.affine(self.p)

--- a/test/functional/test_framework/key.py
+++ b/test/functional/test_framework/key.py
@@ -492,7 +492,10 @@ class ECKey():
         elif isinstance(other, ECPubKey):
             return other * self
         else:
-            raise TypeError
+            # ECKey().set() checks that other is an `int` or `bytes`
+            assert self.valid
+            second = ECKey().set(other, self.compressed)
+            return self * second
 
     def add(self, data):
         """Add key to scalar data. Returns compressed key."""


### PR DESCRIPTION
This adds what we talked about.
1. `get_y()` `get_x()` functions for ECPubKey.
2. ECPubKey `__mul__` support for integers and 32 bytes